### PR TITLE
Add a page for service providers, along with a couple links to it.

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -5,6 +5,11 @@ Contact the community
 
 Want to talk with the Aegir community? There are many channels with various virtues.
 
+Service Providers
+-----------------
+
+If you need professional support for your Aegir installation, check out the [Service Providers page](/community/services.md).
+
 IRC
 ---
 

--- a/docs/community/services.md
+++ b/docs/community/services.md
@@ -1,0 +1,32 @@
+Aegir Service Providers
+=======================
+
+
+Ægir Cooperative
+----------------
+
+The members of the Aegir [core maintainers team](/community/core-team.md), along with other contributors, service providers, and experts, have formed the [Ægir Cooperative](http://aegir.coop) in order to:
+
+* Provide reliable, affordable [support](http://aegir.coop/operations/services/support/) and [consulting](http://aegir.coop/operations/services/consulting/) services for the Aegir Hosting System; and
+* Finance on-going maintenance and development of Aegir and related projects.
+
+[Contact the Ægir Coop](<maillto:info@aegir.coop>) for any Aegir-related expertise that you may require.
+
+
+Other service providers
+-----------------------
+
+Below is a list of individual consulting and hosting firms offering paid support for the Aegir Hosting System:
+
+* [Colan Schwartz Consulting](https://colan.consulting/) ✔
+* [Ergon Logic Enterprises](http://ergonlogic.com) ✔
+* [Initfour websolutions](https://www.initfour.nl) ✔
+* [Koumbit Networks](https://www.koumbit.org)
+* [Omega8.cc](https://omega8.cc/)
+* [Praxis Labs Coop](https://praxis.coop) ✔
+* [SymbioTIC Coop](https://www.symbiotic.coop) ✔
+* [ThinkDrop Consulting](http://www.thinkdrop.net) ✔
+
+✔ indicates that this firm is a member of the Ægir Cooperative.
+
+If your firm provides Aegir-related services, but is not listed above, feel free to submit a pull request to add a link to your website [here](https://github.com/aegir-project/documentation). Also, please consider joining the Ægir Cooperative, and contributing back to the project.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,3 +6,5 @@ Aegir is a powerful hosting system that sits alongside a LAMP or LEMP server to 
 Once Aegir is installed, you can setup a Drupal site in just a few clicks. Aegir creates the web server's site configuration files, the site's database, runs the Drupal installation process and reloads the relevant services, all automatically.
 
 This documentation will help you understand Aegir and how to get it set up and running, as well as how to use it on an ongoing basis.
+
+If you need professional support for your Aegir installation, check out the [Service Providers page](/community/services.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ pages:
     - 'Leadership': 'community/core-team/leadership.md'
     - 'Welcoming a new member': 'community/core-team/welcome.md'
   - 'Resources': 'community/resources.md'
+  - 'Service providers': 'community/services.md'
 - 'Release notes': 'release-notes/3.10.md'
 - 'Release notes':
   - '3.0': 'release-notes/3.0.md'


### PR DESCRIPTION
We used to have such a page, but it never got ported to the new docs.

Separate from this issue, per se, we might want to add a link to the service providers page on our landing page too.